### PR TITLE
fix: 繰上返済時の総返済額に繰上返済額を含めるよう修正

### DIFF
--- a/src/components/ComparisonView.tsx
+++ b/src/components/ComparisonView.tsx
@@ -19,6 +19,7 @@ export function ComparisonView({ scenarios }: ComparisonViewProps) {
         title: title,
         color: COLORS[index],
         originalPrincipal: scenario.principal,
+        earlyRepayments: scenario.earlyRepayments || [],
       };
     })
     .filter((s) => s !== null);
@@ -41,6 +42,7 @@ export function ComparisonView({ scenarios }: ComparisonViewProps) {
           title={scenario.title}
           color={scenario.color}
           originalPrincipal={scenario.originalPrincipal}
+          earlyRepayments={scenario.earlyRepayments}
         />
       ))}
     </div>

--- a/src/components/RepaymentSchedule.tsx
+++ b/src/components/RepaymentSchedule.tsx
@@ -1,14 +1,17 @@
-import type { MonthlyPayment } from '../utils/mortgageCalculator';
+import type { MonthlyPayment, EarlyRepayment } from '../utils/mortgageCalculator';
 
 interface RepaymentScheduleProps {
   schedule: MonthlyPayment[];
   title: string;
   color: string;
   originalPrincipal: number;
+  earlyRepayments?: EarlyRepayment[];
 }
 
-export function RepaymentSchedule({ schedule, title, color, originalPrincipal }: RepaymentScheduleProps) {
-  const totalPayment = schedule.reduce((sum, p) => sum + p.payment, 0);
+export function RepaymentSchedule({ schedule, title, color, originalPrincipal, earlyRepayments = [] }: RepaymentScheduleProps) {
+  const monthlyTotal = schedule.reduce((sum, p) => sum + p.payment, 0);
+  const earlyRepaymentTotal = earlyRepayments.reduce((sum, er) => sum + er.amount, 0);
+  const totalPayment = monthlyTotal + earlyRepaymentTotal;
   const totalInterest = schedule.reduce((sum, p) => sum + p.interest, 0);
   const totalPrincipal = originalPrincipal;
 


### PR DESCRIPTION
## 概要
繰上返済を行った場合、総返済額に繰上返済額が含まれていなかったバグを修正しました。

## 変更内容
- RepaymentSchedule.tsxにearlyRepaymentsプロパティを追加
- 総返済額の計算時に繰上返済額を加算するよう修正
- ComparisonView.tsxでearlyRepaymentsをRepaymentScheduleに渡すよう修正

## テスト結果
-  繰上返済なし: 38,579,239
-  繰上返済あり（100万円）: 38,206,128（約37万円の利息軽減）

Fixes #1