### PR TITLE
fix: 年利率のデフォルト値を1.5%から0.8%に変更

### DIFF
--- a/src/components/LoanInputForm.tsx
+++ b/src/components/LoanInputForm.tsx
@@ -12,7 +12,7 @@ export function LoanInputForm({ onCalculate, initialValues }: LoanInputFormProps
     initialValues?.principal ? String(initialValues.principal / 10000) : '3000'
   );
   const [annualRate, setAnnualRate] = useState(
-    initialValues?.annualRate !== undefined ? String(initialValues.annualRate) : '1.5'
+    initialValues?.annualRate !== undefined ? String(initialValues.annualRate) : '0.8'
   );
   const [years, setYears] = useState(initialValues?.years || 35);
   const [earlyRepaymentsManEn, setEarlyRepaymentsManEn] = useState<Array<{ month: number; amount: number; type: 'period-reduction' | 'payment-reduction' }>>(


### PR DESCRIPTION
## 概要
年利率のデフォルト値を1.5%から0.8%に変更しました。

## 変更内容
- \LoanInputForm.tsx\の\nnualRate\の初期値を\'1.5'\から\'0.8'\に変更

## テスト結果
-  デフォルト値が0.8%になっていることを確認
-  計算が正常に行われることを確認

Fixes #2